### PR TITLE
Add calculate and operate functions to help in calculating the result

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,7 @@
 import Display from './Display';
 import ButtonPanel from './ButtonPanel';
+// eslint-disable-next-line no-unused-vars
+import calculate from '../logic/calculate';
 
 function App() {
   return (

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -10,8 +10,8 @@ const calculate = (data, buttonName) => {
 
   // Return the percentage of the recently typed number
   if (buttonName === '%') {
-    if (!next) return { total: (total / 100).toString, next, operation };
-    if (!total) return { total, next: (next / 100).toString, operation };
+    if (!next) return { total: operate(total, next, buttonName).toString(), next, operation };
+    if (!total) return { total, next: operate(next, total, buttonName).toString(), operation };
   }
 
   // Add a dot at the end of the recently typed number

--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -1,0 +1,48 @@
+import operate from './operate';
+
+const calculate = (data, buttonName) => {
+  const { total, next, operation } = data;
+
+  // Reset all values if AC is clicked or the result/total is an error
+  if (buttonName === 'AC' || total === 'Error') {
+    return { total: null, next: null, operation: null };
+  }
+
+  // Return the percentage of the recently typed number
+  if (buttonName === '%') {
+    if (!next) return { total: (total / 100).toString, next, operation };
+    if (!total) return { total, next: (next / 100).toString, operation };
+  }
+
+  // Add a dot at the end of the recently typed number
+  if (buttonName === '.') {
+    if (!next) return { total: `${total}${buttonName}`, next, operation };
+    if (!total) return { total, next: `${next}${buttonName}`, operation };
+  }
+
+  // Multiply by -1, the recently typed number
+  if (buttonName === '+/-') {
+    if (!next) return { total: (total * -1).toString(), next, operation };
+    if (!total) return { total, next: (next * -1).toString(), operation };
+  }
+
+  // If both operands are available, calculate the result
+  // If there is only one operand, assign it to the total to leave space for the second operand
+  if (['+', '-', 'X', '÷'].includes(buttonName)) {
+    if (total && next) {
+      return { total: (operate(total, next, buttonName)).toString(), next: null, operation: null };
+    }
+    return { total: total ?? next, next: null, operation: buttonName };
+  }
+
+  if (buttonName === '=') {
+    if (total && next) {
+      return { total: (operate(total, next, operation)).toString(), next: null, operation: null };
+    }
+    return { total: total ?? next, next: null, operation };
+  }
+
+  return { total, next, operation };
+};
+
+export default calculate;

--- a/src/logic/operate.js
+++ b/src/logic/operate.js
@@ -1,0 +1,14 @@
+import Big from 'big.js';
+
+// eslint-disable-next-line consistent-return
+const operate = (numberOne, numberTwo, operation) => {
+  const operand1 = Big(numberOne);
+  const operand2 = Big(numberTwo);
+
+  if (operation === '-') return operand1.minus(operand2);
+  if (operation === '+') return operand1.plus(operand2);
+  if (operation === 'X') return operand1.times(operand2);
+  if (operation === '÷') return operand1.div(operand2);
+};
+
+export default operate;

--- a/src/logic/operate.js
+++ b/src/logic/operate.js
@@ -1,14 +1,30 @@
 import Big from 'big.js';
 
-// eslint-disable-next-line consistent-return
 const operate = (numberOne, numberTwo, operation) => {
   const operand1 = Big(numberOne);
   const operand2 = Big(numberTwo);
+  let result = 0;
 
-  if (operation === '-') return operand1.minus(operand2);
-  if (operation === '+') return operand1.plus(operand2);
-  if (operation === 'X') return operand1.times(operand2);
-  if (operation === '÷') return operand1.div(operand2);
+  switch (operation) {
+    case '-':
+      result = operand1.minus(operand2);
+      break;
+    case '+':
+      result = operand1.plus(operand2);
+      break;
+    case 'X':
+      result = operand1.times(operand2);
+      break;
+    case '÷':
+      result = operand1.div(operand2);
+      break;
+    case '%':
+      result = operand1.div(100);
+      break;
+    default:
+      break;
+  }
+  return result;
 };
 
 export default operate;


### PR DESCRIPTION
In this pull request, I did the following:
- Created two functions; operate and calculate
- The Operate function takes in two numbers and an operator sign and returns the result
- The Calculate function modifies the input object depending on the clicked operator sign